### PR TITLE
Rewrite for `beam-refactor`

### DIFF
--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -22,7 +22,7 @@ pattern = FilePattern(make_url, concat_dim)
 recipe = (
     beam.Create(pattern.items())
     | OpenURLWithFSSpec()
-    | OpenWithXarray(file_type=pattern.file_type)
+    | OpenWithXarray(xarray_open_kwargs={"decode_coords": "all"})
     | StoreToZarr(
         store_name="gpcp",
         combine_dims=pattern.combine_dim_keys,

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -24,6 +24,7 @@ recipe = (
     | OpenURLWithFSSpec()
     | OpenWithXarray(file_type=pattern.file_type)
     | StoreToZarr(
+        store_name="gpcp",
         combine_dims=pattern.combine_dim_keys,
     )
 )

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -22,7 +22,7 @@ pattern = FilePattern(make_url, concat_dim)
 recipe = (
     beam.Create(pattern.items())
     | OpenURLWithFSSpec()
-    | OpenWithXarray(file_type=self.file_type, xarray_open_kwargs={"decode_coords": "all"})
+    | OpenWithXarray(file_type=pattern.file_type, xarray_open_kwargs={"decode_coords": "all"})
     | StoreToZarr(
         store_name="gpcp",
         combine_dims=pattern.combine_dim_keys,

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -1,7 +1,7 @@
 import apache_beam as beam
 import pandas as pd
 
-from pangeo_forge_recipes.patterns import ConcatDim, FilePattern, prune_pattern
+from pangeo_forge_recipes.patterns import ConcatDim, FilePattern
 from pangeo_forge_recipes.transforms import OpenURLWithFSSpec, OpenWithXarray, StoreToZarr
 
 dates = [
@@ -18,10 +18,6 @@ concat_dim = ConcatDim("time", dates, nitems_per_file=1)
 pattern = FilePattern(make_url, concat_dim)
 
 
-# FIXME[1]: How is `--prune` going to work in runner?
-# We can't have contributors calling `prune_pattern` themselves...
-pattern_pruned = prune_pattern(pattern)
-
 # FIXME[2]: Dynamic assignment of `target_path` (and `cache_path`)?
 # from tempfile import TemporaryDirectory
 # td = TemporaryDirectory()
@@ -29,10 +25,10 @@ target_path = "output.zarr"
 
 recipe = (
     # FIXME[1]: `pattern_pruned`
-    beam.Create(pattern_pruned.items())
+    beam.Create(pattern.items())
     | OpenURLWithFSSpec()
     # FIXME[1]: `pattern_pruned`
-    | OpenWithXarray(file_type=pattern_pruned.file_type)
+    | OpenWithXarray(file_type=pattern.file_type)
     | StoreToZarr(
         # FIXME[2]: `target_path`
         target_url=target_path,

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -1,6 +1,8 @@
+import apache_beam as beam
 import pandas as pd
-from pangeo_forge_recipes.patterns import ConcatDim, FilePattern
-from pangeo_forge_recipes.recipes import XarrayZarrRecipe
+
+from pangeo_forge_recipes.patterns import ConcatDim, FilePattern, prune_pattern
+from pangeo_forge_recipes.transforms import OpenURLWithFSSpec, OpenWithXarray, StoreToZarr
 
 dates = [
     d.to_pydatetime().strftime('%Y%m%d')
@@ -15,8 +17,25 @@ def make_url(time):
 concat_dim = ConcatDim("time", dates, nitems_per_file=1)
 pattern = FilePattern(make_url, concat_dim)
 
-recipe = XarrayZarrRecipe(
-    pattern,
-    inputs_per_chunk=200,
-    xarray_open_kwargs={"decode_coords": "all"}
+
+# FIXME[1]: How is `--prune` going to work in runner?
+# We can't have contributors calling `prune_pattern` themselves...
+pattern_pruned = prune_pattern(pattern)
+
+# FIXME[2]: Dynamic assignment of `target_path` (and `cache_path`)?
+from tempfile import TemporaryDirectory
+td = TemporaryDirectory()
+target_path = td.name + "/output.zarr"
+
+recipe = (
+    # FIXME[1]: `pattern_pruned`
+    beam.Create(pattern_pruned.items())
+    | OpenURLWithFSSpec()
+    # FIXME[1]: `pattern_pruned`
+    | OpenWithXarray(file_type=pattern_pruned.file_type)
+    | StoreToZarr(
+        # FIXME[2]: `target_path`
+        target_url=target_path,
+        combine_dims=pattern.combine_dim_keys,
+    )
 )

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -23,9 +23,9 @@ pattern = FilePattern(make_url, concat_dim)
 pattern_pruned = prune_pattern(pattern)
 
 # FIXME[2]: Dynamic assignment of `target_path` (and `cache_path`)?
-from tempfile import TemporaryDirectory
-td = TemporaryDirectory()
-target_path = td.name + "/output.zarr"
+# from tempfile import TemporaryDirectory
+# td = TemporaryDirectory()
+target_path = "output.zarr"
 
 recipe = (
     # FIXME[1]: `pattern_pruned`

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -22,7 +22,7 @@ pattern = FilePattern(make_url, concat_dim)
 recipe = (
     beam.Create(pattern.items())
     | OpenURLWithFSSpec()
-    | OpenWithXarray(xarray_open_kwargs={"decode_coords": "all"})
+    | OpenWithXarray(file_type=self.file_type, xarray_open_kwargs={"decode_coords": "all"})
     | StoreToZarr(
         store_name="gpcp",
         combine_dims=pattern.combine_dim_keys,

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -18,20 +18,12 @@ concat_dim = ConcatDim("time", dates, nitems_per_file=1)
 pattern = FilePattern(make_url, concat_dim)
 
 
-# FIXME[2]: Dynamic assignment of `target_path` (and `cache_path`)?
-# from tempfile import TemporaryDirectory
-# td = TemporaryDirectory()
-target_path = "output.zarr"
 
 recipe = (
-    # FIXME[1]: `pattern_pruned`
     beam.Create(pattern.items())
     | OpenURLWithFSSpec()
-    # FIXME[1]: `pattern_pruned`
     | OpenWithXarray(file_type=pattern.file_type)
     | StoreToZarr(
-        # FIXME[2]: `target_path`
-        target_url=target_path,
         combine_dims=pattern.combine_dim_keys,
     )
 )

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/pangeo-forge/pangeo-forge-recipes@beam-refactor

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/pangeo-forge/pangeo-forge-recipes@beam-refactor
+pangeo-forge-recipes==0.10.0


### PR DESCRIPTION
For testing https://github.com/pangeo-forge/pangeo-forge-runner/pull/48.

Unresolved items marked `FIXME` inline.

Before merge, we can make a `0.9.x` tag or similar from `main`, to preserve pre-`beam-refactor` testing.

With `pangeo-forge-recipes` installed from `beam-refactor`, the recipe in this PR can be executed with:

```python
In [1]: from recipe import recipe, target_path

In [2]: import apache_beam as beam

In [3]: with beam.Pipeline() as p:
   ...:     p | recipe
   ...: 

In [4]: import xarray as xr

In [5]: ds = xr.open_dataset(target_path, engine="zarr")

In [6]: ds
Out[6]: 
<xarray.Dataset>
Dimensions:      (latitude: 180, nv: 2, longitude: 360, time: 2)
Coordinates:
  * latitude     (latitude) float32 -90.0 -89.0 -88.0 -87.0 ... 87.0 88.0 89.0
  * longitude    (longitude) float32 0.0 1.0 2.0 3.0 ... 356.0 357.0 358.0 359.0
  * time         (time) datetime64[ns] 1996-10-01 1996-10-02
Dimensions without coordinates: nv
Data variables:
    lat_bounds   (latitude, nv) float32 ...
    lon_bounds   (longitude, nv) float32 ...
    precip       (time, latitude, longitude) float32 ...
    time_bounds  (time, nv) datetime64[ns] ...
Attributes: (12/41)
    Conventions:                CF-1.6, ACDD 1.3

```