### PR TITLE
Flink 0.10.0 Requirements for Integration Tests 

### DIFF
--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,1 +1,2 @@
+s3fs
 pangeo-forge-recipes==0.10.0


### PR DESCRIPTION
I assume we'll want to tag this `0.10.0-flink `to match what's happening [Dataflow over here](https://github.com/pangeo-forge/pangeo-forge-runner/blob/main/tests/integration/test_dataflow_integration.py#L48-L50)?